### PR TITLE
histogram now works with moment.js objects instead of JavaScript Date objects

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -4,9 +4,9 @@
 
     <head>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/d3/3.5.6/d3.min.js" charset="utf-8"></script>
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0-alpha1/jquery.min.js"></script>
         <script src="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.js"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.10.6/moment.min.js"></script>
+        <script src="http://momentjs.com/downloads/moment-timezone.min.js"></script>
 
         <link rel="stylesheet" href="styles/style.css">
         <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet/v0.7.7/leaflet.css" />
@@ -20,7 +20,7 @@
         <script src="ts/dataloader.js"></script>
         <script src="ts/histogram.js"></script>
         <script src="ts/map.js"></script>
-        <script src="ts/timeline.js"></script>
+<!--        <script src="ts/timeline.js"></script>  -->
         <script src="ts/main-script.js"></script>
 
     </body>

--- a/src/ts/dataloader.ts
+++ b/src/ts/dataloader.ts
@@ -68,7 +68,7 @@ class DataLoader {
 
                 that._data = JSON.parse(xmlHttp.responseText);
                 for (let elem of that._data) {
-                    elem.date = moment.tz(elem.datestr, 'YYYY-MM-DDTHH:mm:ss', 'America/Chicago');
+                    elem.moment = moment.tz(elem.datestr, 'YYYY-MM-DDTHH:mm:ss', 'America/Chicago');
                 }
             }
         };

--- a/src/ts/histogram.ts
+++ b/src/ts/histogram.ts
@@ -1,11 +1,12 @@
 
 interface IDataRow {
-    date: Date;
-    casenumber: string;
+    datestr    : string;
+    moment     : moment.Moment;
+    casenumber : string;
     description: string;
-    primary: string;
-    latitude: number;
-    longitude: number;
+    primary    : string;
+    latitude   : number;
+    longitude  : number;
 }
 
 
@@ -15,42 +16,48 @@ interface IDataRow {
 class Histogram {
 
     private _countdata                 : Array<any>;
-    private _dateExtent                : Array<Date>;
-    private _dateTimeFirst             : Date;
-    private _dateTimeLast              : Date;
+    private _dateExtent                : moment.Moment[];
+    private _dateTimeFirst             : moment.Moment;
+    private _dateTimeLast              : moment.Moment;
     private _max                       : number;
     private _min                       : number;
     private _nMilliSecondsPerDay       : number;
     private _numberOfRecords           : number;
     private _xDomainExtent             : number;
-    private _xDomainFrom               : Date;
-    private _xDomainSpacing            : number;
-    private _xDomainTo                 : Date;
+    private _xDomainFrom               : moment.Moment;
+    private _xDomainTo                 : moment.Moment;
     private _yDomainExtent             : number;
     private _yDomainFrom               : number;
     private _yDomainSpacing            : number;
     private _yDomainTo                 : number;
 
-    constructor (data: IDataRow) {
+    constructor (data: any) {
 
         this.nMilliSecondsPerDay = 60 * 60 * 24 * 1000;
 
         this.numberOfRecords = (data as any).length;
 
         // get the minimum and maximum datetime stamps from the dataset:
-        //this.dateExtent = d3.extent(data, function (d:IDataRow) {return d.date; });
+        this.dateExtent = [];
+        this.dateExtent[0] = data[0].moment;
+        this.dateExtent[1] = data[0].moment;
+        for (let elem of data) {
+            if (elem.moment < this.dateExtent[0]) {
+                this.dateExtent[0] = elem.moment;
+            }
+            if (elem.moment > this.dateExtent[1]) {
+                this.dateExtent[1] = elem.moment;
+            }
+        }
+
         this.dateTimeFirst = this.dateExtent[0];
         this.dateTimeLast = this.dateExtent[1];
 
         // size descriptors of the horizontal dimension
-        this.xDomainFrom = new Date(this.dateExtent[0].getFullYear(),
-                                    this.dateExtent[0].getMonth(),
-                                    this.dateExtent[0].getDate(), 0, 0, 0);
-        this.xDomainTo = new Date(this.dateExtent[1].getFullYear(),
-                                  this.dateExtent[1].getMonth(),
-                                  this.dateExtent[1].getDate(), 0, 0, 0, this.nMilliSecondsPerDay);
-        this.xDomainSpacing = 1;
-        this.xDomainExtent = (this.xDomainTo.getTime() - this.xDomainFrom.getTime()) / this.nMilliSecondsPerDay;
+        this.xDomainFrom = this.dateExtent[0].clone().startOf('day');
+        this.xDomainTo = this.dateExtent[1].clone().add(1, 'days').startOf('day');
+
+        this.xDomainExtent = this.xDomainTo.diff(this.xDomainFrom, 'days', false);
 
         // size descriptors of the vertical dimension
         this.yDomainFrom = 0;
@@ -74,8 +81,8 @@ class Histogram {
             for (iHour = 0; iHour < nHours; iHour += 1) {
                 this.countData[iElem] = {
                     'count': null,
-                    'dateFrom': new Date(this.xDomainFrom.getTime() + this.nMilliSecondsPerDay * iDay),
-                    'dateTo': new Date(this.xDomainFrom.getTime() + this.nMilliSecondsPerDay * (iDay + 1)),
+                    'dateFrom': this.xDomainFrom.clone().add(moment.duration(iDay, 'days')),
+                    'dateTo': this.xDomainFrom.clone().add(moment.duration(iDay + 1, 'days')),
                     'todFrom': iHour,
                     'todTo': iHour + 1
                 };
@@ -99,12 +106,16 @@ class Histogram {
         // count occurences
         for (let elem of data as any) {
 
-            iDay = Math.floor((elem.date.getTime() - this.xDomainFrom.getTime()) / this.nMilliSecondsPerDay / this.xDomainSpacing);
-            iHour = Math.floor((elem.date.getHours() - this.yDomainFrom) / this.yDomainSpacing);
+            iDay = Math.floor(elem.moment.diff(this.xDomainFrom, 'days', true));
+            iHour = Math.floor(elem.moment.diff(elem.moment.startOf('day'), 'hours', true));
 
             let iElem = iDay * 24 + iHour;
-
-            this.countData[iElem].count += 1;
+            console.log(iDay, iHour, iElem);
+            if (this.countData[iElem].count) {
+                this.countData[iElem].count += 1;
+            } else {
+                this.countData[iElem].count = 1;
+            }
         }
 
         // determine the maximum value in the histogram
@@ -126,27 +137,27 @@ class Histogram {
         this._countdata = countData;
     }
 
-    public get dateExtent():Array<Date> {
+    public get dateExtent():Array<moment.Moment> {
         return this._dateExtent;
     }
 
-    public set dateExtent(dateExtent:Array<Date>) {
+    public set dateExtent(dateExtent:Array<moment.Moment>) {
         this._dateExtent = dateExtent;
     }
 
-    public get dateTimeFirst():Date {
+    public get dateTimeFirst():moment.Moment {
         return this._dateTimeFirst;
     }
 
-    public set dateTimeFirst(dateTimeFirst:Date) {
+    public set dateTimeFirst(dateTimeFirst:moment.Moment) {
         this._dateTimeFirst = dateTimeFirst;
     }
 
-    public get dateTimeLast():Date {
+    public get dateTimeLast():moment.Moment {
         return this._dateTimeLast;
     }
 
-    public set dateTimeLast(dateTimeLast:Date) {
+    public set dateTimeLast(dateTimeLast:moment.Moment) {
         this._dateTimeLast = dateTimeLast;
     }
 
@@ -190,28 +201,19 @@ class Histogram {
         return this._xDomainExtent;
     }
 
-    public set xDomainFrom(xDomainFrom:Date) {
+    public set xDomainFrom(xDomainFrom:moment.Moment) {
         this._xDomainFrom = xDomainFrom;
     }
 
-    public get xDomainFrom():Date {
+    public get xDomainFrom():moment.Moment {
         return this._xDomainFrom;
     }
 
-    public set xDomainSpacing(xDomainSpacing:number) {
-        this._xDomainSpacing = xDomainSpacing;
-    }
-
-    public get xDomainSpacing():number {
-
-        return this._xDomainSpacing;
-    }
-
-    public set xDomainTo(xDomainTo:Date) {
+    public set xDomainTo(xDomainTo:moment.Moment) {
         this._xDomainTo = xDomainTo;
     }
 
-    public get xDomainTo():Date {
+    public get xDomainTo():moment.Moment {
         return this._xDomainTo;
     }
 

--- a/src/ts/main-script.ts
+++ b/src/ts/main-script.ts
@@ -5,7 +5,7 @@
 let dataloader:DataLoader = new DataLoader();
 
 // configure the dataLoader
-dataloader.limit = 3000;
+dataloader.limit = 100;
 
 // load the data
 dataloader.loadData();
@@ -24,5 +24,9 @@ function doit(data: any) {
     };
     map.circleMarkerRadius = 6;
     map.showCrimeLocations();
+
+
+    let histogram:Histogram = new Histogram(dataloader.data);
+    console.log(histogram);
 
 };


### PR DESCRIPTION
The dates we were getting from the chicago dataset were initially interpreted as if they were recorded in the timezone the browser happens to be using. This is not correct, so the DataLoader object was changed to use the moment.js library's moment objects with additional timezone information. 

This meant that the Histogram object also needed to change, in order to construct the heatmap/histogram.
